### PR TITLE
Raise KeyError when requested key not found

### DIFF
--- a/lib/conf_loader.rb
+++ b/lib/conf_loader.rb
@@ -24,10 +24,19 @@ class ConfLoader
 
     if environments.has_key?(env)
       hash = environments[env]
-      Symbolizer.symbolize(hash)
+      guarantee_key_presence(Symbolizer.symbolize(hash))
     else
       raise EnvironmentNotFoundError,
         "Configuration for `#{env}` not found at path #{path}"
     end
   end
+
+  def self.guarantee_key_presence(hash)
+    hash.default_proc = proc do |h, k|
+      raise KeyError, "#{k} not defined"
+    end
+    hash
+  end
+
+  private_class_method :guarantee_key_presence
 end

--- a/lib/conf_loader/version.rb
+++ b/lib/conf_loader/version.rb
@@ -1,3 +1,3 @@
 class ConfLoader
-  VERSION = '0.2.2'
+  VERSION = '1.0.0'
 end

--- a/spec/integration/conf_loader_spec.rb
+++ b/spec/integration/conf_loader_spec.rb
@@ -11,6 +11,14 @@ describe ConfLoader do
     end
   end
 
+  context 'when accessed key not defined' do
+    let(:conf) { described_class.load(path, 'office') }
+
+    it 'raises KeyError' do
+      expect{conf[:some_undefined_key]}.to raise_error(KeyError)
+    end
+  end
+
   context 'conf loaded with production deployment setting' do
 
     let(:conf) { described_class.load(path, 'production') }
@@ -39,10 +47,6 @@ describe ConfLoader do
 
     it 'exposes ENV defined value' do
       expect(conf[:foo]).to eq('foo-value')
-    end
-
-    it 'exposes undefined ENV values as nil' do
-      expect(conf[:undefined_val]).to be_nil
     end
 
     it 'exposes default value when ENV value not supplied' do


### PR DESCRIPTION
The hash loaded from a configuration file now has default key behavior
to raise KeyError.

As this is not backwards-compatible behavior, the version has been raise
to 1.0.0.