### PR TITLE
Check values are defined and not empty

### DIFF
--- a/lib/conf_loader/version.rb
+++ b/lib/conf_loader/version.rb
@@ -1,3 +1,3 @@
 class ConfLoader
-  VERSION = '1.0.0'
+  VERSION = '2.0.0'
 end

--- a/spec/fixtures/simple.yml
+++ b/spec/fixtures/simple.yml
@@ -10,3 +10,8 @@ flexible:
   foo: <%= ENV['FOO'] %>
   var_with_default_not_in_env: <%= ENV['SOME_VAR_NOT_IN_ENV'] || 'default_value' %>
   var_with_default_in_env: <%= ENV['FOO'] || 'default_value' %>
+
+invalid:
+  empty_value: ''
+  nested_field:
+    nested_empty_value: ''

--- a/spec/integration/conf_loader_spec.rb
+++ b/spec/integration/conf_loader_spec.rb
@@ -58,4 +58,14 @@ describe ConfLoader do
     end
   end
 
+  context 'with empty config value' do
+    let(:conf) { described_class.load(path, 'invalid') }
+
+    it 'raises ValueNotDefinedError' do
+      expect{conf}.to raise_error(
+        described_class::ValueNotDefinedError,
+        'empty_value value not defined, nested_empty_value value not defined'
+      )
+    end
+  end
 end


### PR DESCRIPTION
Ensure configuration has non-empty values.
Bum version to 2.0.0 as the change is not backward compatible.