### PR TITLE
Include full path for invalid keys

### DIFF
--- a/lib/conf_loader.rb
+++ b/lib/conf_loader.rb
@@ -46,11 +46,11 @@ class ConfLoader
   end
 
   def self.check_value_presence(hash)
-    errors = check_values_not_empty(hash)
-    if errors.empty?
+    error_keys = check_values_not_empty(hash)
+    if error_keys.empty?
       hash
     else
-      raise ValueNotDefinedError, errors.join(', ')
+      raise ValueNotDefinedError, "Undefined keys: #{error_keys.join(', ')}"
     end
   end
 
@@ -58,9 +58,9 @@ class ConfLoader
     hash.inject([]) do |acc, (key, value)|
       errors =
         if value.is_a?(Hash)
-          check_values_not_empty(value)
+          check_values_not_empty(value).map { |child_key| "#{key}.#{child_key}" }
         elsif value.to_s.empty?
-          ["#{key} value not defined"]
+          [key]
         else
           []
         end

--- a/lib/conf_loader/version.rb
+++ b/lib/conf_loader/version.rb
@@ -1,3 +1,3 @@
 class ConfLoader
-  VERSION = '2.0.0'
+  VERSION = '2.1.0'
 end

--- a/spec/fixtures/simple.yml
+++ b/spec/fixtures/simple.yml
@@ -15,3 +15,5 @@ invalid:
   empty_value: ''
   nested_field:
     nested_empty_value: ''
+    nested_empty_value2: ''
+    nested_non_empty_value: 'non-empty'

--- a/spec/integration/conf_loader_spec.rb
+++ b/spec/integration/conf_loader_spec.rb
@@ -64,7 +64,7 @@ describe ConfLoader do
     it 'raises ValueNotDefinedError' do
       expect{conf}.to raise_error(
         described_class::ValueNotDefinedError,
-        'empty_value value not defined, nested_empty_value value not defined'
+        'Undefined keys: empty_value, nested_field.nested_empty_value, nested_field.nested_empty_value2'
       )
     end
   end


### PR DESCRIPTION
Helps to better understand why loading failed when there are multiple keys
with the same name.