### PR TITLE
Support Ruby 3.1+

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,22 @@
+name: Publish Gem
+
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+
+
+      - name: Release Gem
+        uses: discourse/publish-rubygems-action@b55d7b91b55e61752dc6cbc2972f8e16fe6c1a02
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          RUBYGEMS_API_KEY: ${{secrets.RUBYGEMS_API_KEY}}
+          RELEASE_COMMAND: rake release

--- a/lib/conf_loader.rb
+++ b/lib/conf_loader.rb
@@ -21,7 +21,9 @@ class ConfLoader
   # @api public
   def self.load(path, env)
     template = ERB.new File.new(path).read
-    environments = YAML.load template.result(binding)
+    source = template.result(binding)
+
+    environments = load_environments(source)
 
     if environments.has_key?(env)
       hash = environments[env]
@@ -37,6 +39,16 @@ class ConfLoader
 
 
   private_class_method
+
+  if Gem::Version.new(RUBY_VERSION).release >= Gem::Version.new('3.1.0')
+    def self.load_environments(source)
+      YAML.load(source, aliases: true)
+    end
+  else
+    def self.load_environments(source)
+      YAML.load(source)
+    end
+  end
 
   def self.guarantee_key_presence(hash)
     hash.default_proc = proc do |h, k|

--- a/lib/conf_loader/version.rb
+++ b/lib/conf_loader/version.rb
@@ -1,3 +1,3 @@
 class ConfLoader
-  VERSION = '2.1.0'
+  VERSION = '2.2.0'
 end


### PR DESCRIPTION
Loading YAML files had a backwards incompatible change starting
from Ruby 3.1. Namely, Ruby 3.1 comes with Psych 4 which does
not load aliases unless they get the `aliases: true` argument.
The old YAML loading methods (Psych 3), however, do not support
the `aliases` parameter.

To support all Ruby versions, try both methods. It's the same way
how it's done [in Rails][rails].

[rails]: https://github.com/rails/rails/commit/179d0a1f474ada02e0030ac3bd062fc653765dbe