### PR TITLE
Reject alias key after config load

### DIFF
--- a/lib/conf_loader.rb
+++ b/lib/conf_loader.rb
@@ -27,6 +27,7 @@ class ConfLoader
 
     if environments.has_key?(env)
       hash = environments[env]
+      hash = hash.reject {|k, v| k == "<<" }
 
       check_value_presence(
         guarantee_key_presence(Symbolizer.symbolize(hash))


### PR DESCRIPTION
YAML.load with aliases respects aliases, but keeps "<<"=>nil key in the resulting conf hash. Rejecting this key explicitly solves Undefined keys: << errors.